### PR TITLE
try to make a templated getHandleForType function

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1545,6 +1545,19 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_device_info, CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR,      cl::vector<cl_external_semaphore_handle_type_khr>) \
     F(cl_semaphore_info_khr, CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR,      cl::vector<cl_external_semaphore_handle_type_khr>) \
 
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_DX_FENCE_EXT(F) \
+    F(cl_external_semaphore_handle_type_khr, CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR, void*) \
+
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXT(F) \
+    F(cl_external_semaphore_handle_type_khr, CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR, int) \
+
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_SYNC_FD_EXT(F) \
+    F(cl_external_semaphore_handle_type_khr, CL_SEMAPHORE_HANDLE_SYNC_FD_KHR, int) \
+
+#define CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXT(F) \
+    F(cl_external_semaphore_handle_type_khr, CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR, void*) \
+    F(cl_external_semaphore_handle_type_khr, CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR, void*) \
+
 #define CL_HPP_PARAM_NAME_INFO_3_0_(F) \
     F(cl_platform_info, CL_PLATFORM_NUMERIC_VERSION, cl_version) \
     F(cl_platform_info, CL_PLATFORM_EXTENSIONS_WITH_VERSION, cl::vector<cl_name_version>) \
@@ -1655,6 +1668,19 @@ CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_MEMORY_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #if defined(cl_khr_external_semaphore)
 CL_HPP_PARAM_NAME_CL_KHR_SEMAPHORE_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_khr_external_semaphore
+
+#if defined(cl_khr_external_semaphore_dx_fence)
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_DX_FENCE_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_khr_external_semaphore_dx_fence
+#if defined(cl_khr_external_semaphore_opaque_fd)
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_khr_external_semaphore_opaque_fd
+#if defined(cl_khr_external_semaphore_sync_fd)
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_SYNC_FD_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_khr_external_semaphore_sync_fd
+#if defined(cl_khr_external_semaphore_win32)
+CL_HPP_PARAM_NAME_CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXT(CL_HPP_DECLARE_PARAM_TRAITS_)
+#endif // cl_khr_external_semaphore_win32
 
 #if defined(cl_khr_device_uuid)
 using uuid_array = array<cl_uchar, CL_UUID_SIZE_KHR>;
@@ -10506,53 +10532,27 @@ public:
     }
 
 #ifdef cl_khr_external_semaphore
-    cl_int getHandleForTypeKHR (const Device &device,
-        ExternalSemaphoreType handle_type,
-        size_type handle_size,
-        void* handle_ptr,
-        size_type* handle_size_ret)
+    template <typename T>
+    cl_int getHandleForTypeKHR(
+        const Device& device, cl_external_semaphore_handle_type_khr name, T* param) const
     {
-        if (pfn_clGetSemaphoreHandleForTypeKHR == nullptr) {
-            return detail::errHandler(CL_INVALID_OPERATION,
-                    __GET_SEMAPHORE_HANDLE_FOR_TYPE_KHR_ERR);
+        return detail::errHandler(
+            detail::getInfo(
+                pfn_clGetSemaphoreHandleForTypeKHR, object_, device(), name, param),
+                __GET_SEMAPHORE_HANDLE_FOR_TYPE_KHR_ERR);
+    }
+
+    template <cl_external_semaphore_handle_type_khr type> typename
+    detail::param_traits<detail::cl_external_semaphore_handle_type_khr, type>::param_type
+        getHandleForTypeKHR(const Device& device, cl_int* err = nullptr) const
+    {
+        typename detail::param_traits<
+        detail::cl_external_semaphore_handle_type_khr, type>::param_type param;
+        cl_int result = getHandleForTypeKHR(device, type, &param);
+        if (err != nullptr) {
+            *err = result;
         }
-
-        return detail::errHandler(pfn_clGetSemaphoreHandleForTypeKHR(object_,
-            device(),
-            static_cast<cl_external_semaphore_handle_type_khr>(handle_type),
-            handle_size,
-            handle_ptr,
-            handle_size_ret),
-             __GET_SEMAPHORE_HANDLE_FOR_TYPE_KHR_ERR);
-    }
-
-    template<ExternalSemaphoreType handle_type>
-        cl_int getHandleForTypeKHR (const Device &device,
-            size_type handle_size = 0,
-            void* handle_ptr = nullptr,
-            size_type* handle_size_ret = nullptr)
-    {
-         return detail::errHandler(getHandleForTypeKHR(
-            device,
-            handle_type,
-            handle_size,
-            handle_ptr,
-            handle_size_ret),
-             __GET_SEMAPHORE_HANDLE_FOR_TYPE_KHR_ERR);
-    }
-
-    template<ExternalSemaphoreType handle_type, typename T>
-        cl_int getHandleForTypeKHR (const Device &device,
-            T* handle_ptr,
-            size_type* handle_size_ret = nullptr)
-    {
-         return detail::errHandler(getHandleForTypeKHR(
-            device,
-            handle_type,
-            sizeof(T),
-            handle_ptr,
-            handle_size_ret),
-             __GET_SEMAPHORE_HANDLE_FOR_TYPE_KHR_ERR);
+        return param;
     }
 #endif // cl_khr_external_semaphore
 

--- a/tests/test_openclhpp.cpp
+++ b/tests/test_openclhpp.cpp
@@ -393,6 +393,9 @@ void setUp()
     cl::pfn_clReleaseCommandBufferKHR = ::clReleaseCommandBufferKHR;
     cl::pfn_clGetCommandBufferInfoKHR = ::clGetCommandBufferInfoKHR;
 #endif
+#if defined(cl_khr_external_semaphore)
+    cl::pfn_clGetSemaphoreHandleForTypeKHR = ::clGetSemaphoreHandleForTypeKHR;
+#endif
 
     /* We reach directly into the objects rather than using assignment to
      * avoid the reference counting functions from being called.
@@ -3377,5 +3380,137 @@ void testCommandBufferInfoKHRCommandQueues()
     TEST_ASSERT_EQUAL_PTR(make_command_queue(2), command_queues[2]());
 #endif
 }
+
+// Tests for external semaphores:
+#if defined(cl_khr_external_semaphore)
+
+static void* make_external_semaphore_handle(
+    cl_external_semaphore_handle_type_khr handle_type )
+{
+    return (void*)(uintptr_t)(handle_type << 16 | 0x1111);
+}
+
+static int make_external_semaphore_fd(
+    cl_external_semaphore_handle_type_khr handle_type)
+{
+    return (int)(handle_type << 16 | 0x2222);
+}
+
+static cl_int clGetSemaphoreHandleForTypeKHR_GetHandles(
+    cl_semaphore_khr sema_object,
+    cl_device_id device,
+    cl_external_semaphore_handle_type_khr handle_type,
+    size_t handle_size,
+    void* handle_ptr,
+    size_t* handle_size_ret,
+    int num_calls)
+{
+    (void) sema_object;
+    (void) device;
+
+    switch (handle_type) {
+#if defined(cl_khr_external_semaphore_dx_fence)
+    case CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR:
+    {
+        void* ret = make_external_semaphore_handle(handle_type);
+        if (handle_size == sizeof(ret) && handle_ptr) {
+            void** pHandle = static_cast<void**>(handle_ptr);
+            *pHandle = ret;
+        }
+        if (handle_size_ret) {
+            *handle_size_ret = sizeof(ret);
+        }
+        return CL_SUCCESS;
+    }
+#endif
+#if defined(cl_khr_external_semaphore_win32)
+    case CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR:
+    case CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR:
+    {
+        void* ret = make_external_semaphore_handle(handle_type);
+        if (handle_size == sizeof(ret) && handle_ptr) {
+            void** pHandle = static_cast<void**>(handle_ptr);
+            *pHandle = ret;
+        }
+        if (handle_size_ret) {
+            *handle_size_ret = sizeof(ret);
+        }
+        return CL_SUCCESS;
+    }
+#endif
+#if defined(cl_khr_external_semaphore_opaque_fd)
+    case CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR:
+    {
+        int ret = make_external_semaphore_fd(handle_type);
+        if (handle_size == sizeof(ret) && handle_ptr) {
+            int* pHandle = static_cast<int*>(handle_ptr);
+            *pHandle = ret;
+        }
+        if (handle_size_ret) {
+            *handle_size_ret = sizeof(ret);
+        }
+        return CL_SUCCESS;
+    }
+#endif
+#if defined(cl_khr_external_semaphore_opaque_fd)
+    case CL_SEMAPHORE_HANDLE_SYNC_FD_KHR:
+    {
+        int ret = make_external_semaphore_fd(handle_type);
+        if (handle_size == sizeof(ret) && handle_ptr) {
+            int* pHandle = static_cast<int*>(handle_ptr);
+            *pHandle = ret;
+        }
+        if (handle_size_ret) {
+            *handle_size_ret = sizeof(ret);
+        }
+        return CL_SUCCESS;
+    }
+#endif
+    default: break;
+    }
+    TEST_FAIL();
+    return CL_INVALID_OPERATION;
+}
+
+void testTemplateGetSemaphoreHandleForTypeKHR()
+{
+    clGetDeviceInfo_StubWithCallback(clGetDeviceInfo_platform);
+    clGetPlatformInfo_StubWithCallback(clGetPlatformInfo_version_2_0);
+    clReleaseDevice_ExpectAndReturn(make_device_id(0), CL_SUCCESS);
+
+    cl::Device device(make_device_id(0));
+
+    clGetSemaphoreHandleForTypeKHR_StubWithCallback(clGetSemaphoreHandleForTypeKHR_GetHandles);
+
+    cl::Semaphore semaphore;
+#if defined(cl_khr_external_semaphore_dx_fence)
+    {
+        auto handle = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR>(device);
+        TEST_ASSERT_EQUAL(handle, make_external_semaphore_handle(CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR));
+    }
+#endif
+#if defined(cl_khr_external_semaphore_opaque_fd)
+    {
+        auto fd = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR>(device);
+        TEST_ASSERT_EQUAL(fd, make_external_semaphore_fd(CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR));
+    }
+#endif
+#if defined(cl_khr_external_semaphore_sync_fd)
+    {
+        auto fd = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_SYNC_FD_KHR>(device);
+        TEST_ASSERT_EQUAL(fd, make_external_semaphore_fd(CL_SEMAPHORE_HANDLE_SYNC_FD_KHR));
+    }
+#endif
+#if defined(cl_khr_external_semaphore_win32)
+    {
+        auto handle0 = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR>(device);
+        TEST_ASSERT_EQUAL(handle0, make_external_semaphore_handle(CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR));
+        auto handle1 = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR>(device);
+        TEST_ASSERT_EQUAL(handle1, make_external_semaphore_handle(CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR));
+    }
+#endif
+}
+
+#endif // defined(cl_khr_external_semaphore)
 
 } // extern "C"


### PR DESCRIPTION
I thought it might be easier to make a pull request the way I think a templated getHandleForType function should work rather than making more comments on GitHub.  I've included a unit test to show how this could work.

The one thing I don't particularly like about this right now is that it only works with the `CL_`-prefixed enums, and doesn't work with the `ExternalSemaphoreType` enum type.  So, in other words, you can do this:

```c++
auto handle = semaphore.getHandleForTypeKHR<CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR>(device);
```

but you can't do this:

```c++
auto handle = semaphore.getHandleForTypeKHR<ExternalSemaphoreType::D3D12Fence>(device);
```

We could probably make the `ExternalSemaphoreType` variant work with a few additional param traits, though we wouldn't be able to use `CL_HPP_DECLARE_PARAM_TRAITS_` to do them.

Let me know what you think!